### PR TITLE
Add window-title option for screenshot capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ It also ships with JSON files describing game items and trinkets.
 - `opencv-python`
 - `mss`
 - `Pillow`
+- `pygetwindow` (optional, for capturing a specific window)
 
 Install the dependencies with:
 
 ```bash
-pip install opencv-python pyautogui mss pillow
+pip install opencv-python pyautogui mss pillow pygetwindow
 ```
 
 ## Usage
@@ -30,6 +31,7 @@ Optional arguments:
 
 - `--region X Y W H` — screen region to capture (defaults to full screen).
 - `--delay SECONDS` — seconds to wait before the screenshot is taken (defaults to `2`).
+- `--window-title TITLE` — title of the game window to capture if no region is given (defaults to `"The Binding of Isaac"`).
 
 During the delay you can switch focus to the game window. The script will report whether it found the pedestal in the captured image and the coordinates of the match.
 

--- a/src/pedestal_detector.py
+++ b/src/pedestal_detector.py
@@ -4,6 +4,11 @@ from mss import mss
 import argparse
 import time
 
+try:
+    import pygetwindow as gw
+except Exception:  # pragma: no cover - optional dependency may fail
+    gw = None
+
 
 def capture_region(region=None):
     """Grab a screenshot of the given region.
@@ -34,6 +39,19 @@ def match_template(img, template, threshold=0.8):
     return None
 
 
+def get_window_region(title: str):
+    """Return ``(x, y, width, height)`` of the window with the given title."""
+    if gw is None:
+        raise RuntimeError("pygetwindow is required for --window-title")
+
+    windows = gw.getWindowsWithTitle(title)
+    if not windows:
+        raise RuntimeError(f"Window '{title}' not found")
+
+    win = windows[0]
+    return win.left, win.top, win.width, win.height
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Detect item pedestal in Binding of Isaac screenshot"
@@ -52,10 +70,23 @@ def main():
         default=2,
         help="Seconds to wait before capturing the screen",
     )
+    parser.add_argument(
+        "--window-title",
+        default="The Binding of Isaac",
+        help="Window title to capture if --region is not provided",
+    )
     args = parser.parse_args()
 
     time.sleep(args.delay)
-    img = capture_region(args.region)
+    region = args.region
+    if region is None and args.window_title:
+        try:
+            region = get_window_region(args.window_title)
+        except Exception as exc:
+            print(exc)
+            return
+
+    img = capture_region(region)
     template = cv2.imread(args.template)
     if template is None:
         print("Could not load template image:", args.template)


### PR DESCRIPTION
## Summary
- support specifying a window title to capture with pygetwindow
- list `pygetwindow` as optional dependency
- document the `--window-title` option in README

## Testing
- `python -m py_compile src/pedestal_detector.py`

------
https://chatgpt.com/codex/tasks/task_e_685301f17114832e860f144262c0f149