### PR TITLE
Add multi-scale template search

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Optional arguments:
 
 - `--region X Y W H` — screen region to capture (defaults to full screen).
 - `--delay SECONDS` — seconds to wait before the screenshot is taken (defaults to `2`).
+- `--scale-min`, `--scale-max`, `--scale-step` — enable multi-scale search by
+  specifying the range of scales to try. By default the template is resized, but
+  you can use `--scale-target screenshot` to resize the captured image instead.
+  A wider range or smaller step improves detection of differently sized sprites
+  at the cost of additional processing time.
 
 During the delay you can switch focus to the game window. The script will report whether it found the pedestal in the captured image and the coordinates of the match.
 

--- a/src/pedestal_detector.py
+++ b/src/pedestal_detector.py
@@ -34,6 +34,86 @@ def match_template(img, template, threshold=0.8):
     return None
 
 
+def match_template_multi_scale(
+    img,
+    template,
+    threshold=0.8,
+    scale_min=0.8,
+    scale_max=1.2,
+    scale_step=0.1,
+    scale_target="template",
+):
+    """Perform template matching over a range of scales.
+
+    Parameters
+    ----------
+    img : numpy.ndarray
+        Screenshot image.
+    template : numpy.ndarray
+        Template image to search for.
+    threshold : float, optional
+        Minimum matching score required to return a match.
+    scale_min, scale_max, scale_step : float, optional
+        Range of scales to try. ``scale_max`` is inclusive.
+    scale_target : {"template", "screenshot"}
+        Whether to resize the template (default) or the screenshot.
+
+    Returns
+    -------
+    tuple or None
+        ``(top_left, bottom_right, score, scale)`` if a match above the
+        threshold is found, otherwise ``None``.
+    """
+
+    best = None
+    best_score = -1.0
+
+    scales = np.arange(scale_min, scale_max + scale_step / 2, scale_step)
+    for scale in scales:
+        if scale_target == "template":
+            scaled_template = cv2.resize(
+                template,
+                None,
+                fx=scale,
+                fy=scale,
+                interpolation=cv2.INTER_AREA if scale < 1 else cv2.INTER_LINEAR,
+            )
+            if (
+                scaled_template.shape[0] > img.shape[0]
+                or scaled_template.shape[1] > img.shape[1]
+            ):
+                continue
+            result = cv2.matchTemplate(img, scaled_template, cv2.TM_CCOEFF_NORMED)
+            _, max_val, _, max_loc = cv2.minMaxLoc(result)
+            if max_val > best_score:
+                h, w = scaled_template.shape[:2]
+                best = (max_loc, (max_loc[0] + w, max_loc[1] + h), max_val, scale)
+                best_score = max_val
+        else:  # scale the screenshot
+            scaled_img = cv2.resize(
+                img,
+                None,
+                fx=scale,
+                fy=scale,
+                interpolation=cv2.INTER_AREA if scale < 1 else cv2.INTER_LINEAR,
+            )
+            result = cv2.matchTemplate(scaled_img, template, cv2.TM_CCOEFF_NORMED)
+            _, max_val, _, max_loc = cv2.minMaxLoc(result)
+            if max_val > best_score:
+                h, w = template.shape[:2]
+                top_left = (int(max_loc[0] / scale), int(max_loc[1] / scale))
+                bottom_right = (
+                    int((max_loc[0] + w) / scale),
+                    int((max_loc[1] + h) / scale),
+                )
+                best = (top_left, bottom_right, max_val, scale)
+                best_score = max_val
+
+    if best is not None and best[2] >= threshold:
+        return best
+    return None
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Detect item pedestal in Binding of Isaac screenshot"
@@ -52,6 +132,27 @@ def main():
         default=2,
         help="Seconds to wait before capturing the screen",
     )
+    parser.add_argument(
+        "--scale-min",
+        type=float,
+        help="Minimum scale factor for multi-scale search",
+    )
+    parser.add_argument(
+        "--scale-max",
+        type=float,
+        help="Maximum scale factor for multi-scale search",
+    )
+    parser.add_argument(
+        "--scale-step",
+        type=float,
+        help="Step size between scales for multi-scale search",
+    )
+    parser.add_argument(
+        "--scale-target",
+        choices=["template", "screenshot"],
+        default="template",
+        help="Resize this image when performing multi-scale search",
+    )
     args = parser.parse_args()
 
     time.sleep(args.delay)
@@ -61,12 +162,36 @@ def main():
         print("Could not load template image:", args.template)
         return
 
-    match = match_template(img, template)
-    if match:
-        top_left, bottom_right, score = match
-        print(
-            f"Pedestal found with score {score:.2f} at {top_left} -> {bottom_right}"
+    use_multi_scale = (
+        args.scale_min is not None
+        or args.scale_max is not None
+        or args.scale_step is not None
+        or args.scale_target != "template"
+    )
+
+    if use_multi_scale:
+        match = match_template_multi_scale(
+            img,
+            template,
+            scale_min=args.scale_min or 0.8,
+            scale_max=args.scale_max or 1.2,
+            scale_step=args.scale_step or 0.1,
+            scale_target=args.scale_target,
         )
+    else:
+        match = match_template(img, template)
+
+    if match:
+        if len(match) == 4:
+            top_left, bottom_right, score, scale = match
+            print(
+                f"Pedestal found with score {score:.2f} at {top_left} -> {bottom_right} (scale {scale:.2f})"
+            )
+        else:
+            top_left, bottom_right, score = match
+            print(
+                f"Pedestal found with score {score:.2f} at {top_left} -> {bottom_right}"
+            )
     else:
         print("Pedestal not found.")
 


### PR DESCRIPTION
## Summary
- allow searching for templates across multiple scales
- expose scale options in the CLI
- document scale arguments in the README

## Testing
- `python -m py_compile src/pedestal_detector.py`
- `pip install opencv-python mss pyautogui Pillow`

------
https://chatgpt.com/codex/tasks/task_e_685301f3944c832eb0aec736b38712b4