### PR TITLE
Add trinket descriptions

### DIFF
--- a/data/trinkets.json
+++ b/data/trinkets.json
@@ -1,1 +1,12 @@
-{}
+{
+    "aceofspades": "Aumenta a chance de encontrar cartas ao limpar salas.",
+    "curvedhorn": "Concede +2 de dano enquanto segurado.",
+    "cancer": "Diminui o tempo de carga das lágrimas, aumentando a cadência de tiro.",
+    "lefthand": "Transforma todos os baús em baús vermelhos.",
+    "monkeypaw": "Ao sofrer dano letal, gera até três corações negros.",
+    "paperclip": "Permite abrir baús dourados sem gastar chave.",
+    "safetycap": "Aumenta a chance de aparecerem pílulas.",
+    "childsheart": "Aumenta a chance de encontrar corações vermelhos.",
+    "fishhead": "Ao ser atingido, gera uma mosca azul aliada.",
+    "matchstick": "Aumenta a chance de encontrar bombas."
+}


### PR DESCRIPTION
## Summary
- populate `data/trinkets.json` with basic trinket information

## Testing
- `python -m py_compile src/pedestal_detector.py`


------
https://chatgpt.com/codex/tasks/task_e_685304806cd0832eaf48a00367fe688b